### PR TITLE
CEP 43 update: Improvements to faulty validator handling

### DIFF
--- a/text/0043-better-eviction.md
+++ b/text/0043-better-eviction.md
@@ -6,8 +6,9 @@
 
 CEP PR: [casperlabs/ceps#0043](https://github.com/casperlabs/ceps/pull/0043)
 
-Exclude validators that equivocated or were inactive in one era from proposing blocks in all future
-eras, even before the `auction_delay`.
+Exclude validators that equivocated in one era from proposing blocks in all future eras, even
+before the `auction_delay`, and exclude validators that were inactive in one era from proposing
+blocks in the next.
 
 
 ## Motivation
@@ -48,8 +49,7 @@ validator weights.
 
 If after the auction a validator equivocates, it is still set to `Banned` status when the era is
 initialized. These banned validators are now excluded from the proposer sequence. In addition, we
-also exclude validators that were inactive in a recent era. I.e. whenever we know that a validator
-is about to be evicted, we exclude them.
+also exclude validators that were inactive in the previous era.
 
 Now the actual proposer sequence is modified:
 * If the proposer computation with the original set of weights returns a validator that was not


### PR DESCRIPTION
While malicious validators should be banned until they get removed from the validator set by the auction contract, inactive validators just need to be excluded from proposing blocks in the next era. If they become active again, it is fine to add them back to the leader sequence in the era after that.

This change doesn't make a difference in mainnet anyway, because the `auction_delay` is 1.

https://casperlabs.atlassian.net/browse/HWY-280