### PR TITLE
CEP 78: Enhanced NFT standard

### DIFF
--- a/text/0078-enhanced-nft-standard.md
+++ b/text/0078-enhanced-nft-standard.md
@@ -301,5 +301,9 @@ by using the provided `Makefile` and running the `make test` command.
 
 [prior-art]: #prior-art
 
+The Casper NFT Protocol [1]
+The Ethereum NFT standard EIP-721[2]
+
+
 1. [`CEP-47`](https://github.com/casper-network/ceps/pull/47)
 2. [`EIP-721`](https://eips.ethereum.org/EIPS/eip-721)


### PR DESCRIPTION
Currently draft, to obtain number, will follow up and mark the standard for ready later